### PR TITLE
Remove Costura.Fody and LiveTokenHelper.dll references

### DIFF
--- a/ShadowrunLauncher/ShadowrunLauncher/FodyWeavers.xml
+++ b/ShadowrunLauncher/ShadowrunLauncher/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
-</Weavers>

--- a/ShadowrunLauncher/ShadowrunLauncher/ShadowrunLauncher.csproj
+++ b/ShadowrunLauncher/ShadowrunLauncher/ShadowrunLauncher.csproj
@@ -16,6 +16,7 @@
 	<None Remove="Audio\buttonClick.wav" />
 	<None Remove="Audio\buttonHover.wav" />
 	<None Remove="Fonts\Shadowrun Regular.ttf" />
+	<None Remove="LiveTokenHelper.dll" />
 	<Content Include="Audio\backgroundAmbience.wav">
 	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</Content>
@@ -29,22 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
   </ItemGroup>
 
   <ItemGroup>
     <Resource Include="Cursors\cursor.cur" />
     <Resource Include="Fonts\Shadowrun Regular.ttf" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="LiveTokenHelper.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This commit removes the `Costura` weaver from `FodyWeavers.xml`, indicating that the project will no longer use the Costura.Fody library. Additionally, the `LiveTokenHelper.dll` has been marked for removal in `ShadowrunLauncher.csproj`, along with its associated `PackageReference` and copy settings. This streamlines the project by eliminating unnecessary dependencies.